### PR TITLE
Populate teaching page with course overview

### DIFF
--- a/_pages/teaching.md
+++ b/_pages/teaching.md
@@ -2,11 +2,31 @@
 layout: page
 permalink: /teaching/
 title: teaching
-description: Materials for courses you taught. Replace this text with your description.
+description: Graduate- and professional-level courses in machine learning, data science, and statistics for financial technology.
 nav: true
 nav_order: 5
 ---
 
-For now, this page is assumed to be a static description of your courses. You can convert it to a collection similar to `_projects/` so that you can have a dedicated page for each course.
+## Duke University · Pratt School of Engineering
 
-Organize your courses by years, topics, or universities, however you like!
+### FINTECH 540: Machine Learning for FinTech
+- **Format:** Graduate course on machine learning applications across the fintech industry.
+- **Highlights:** Explored how supervised, unsupervised, and reinforcement learning techniques address rapidly evolving challenges in digital finance through extensive coding sessions that use real financial data.
+
+### FINTECH/ECE 590: Data Wrangling and Visualization with Python
+- **Format:** Graduate special topics course cross-listed in Electrical & Computer Engineering.
+- **Highlights:** Focused on end-to-end data pipelines for analytics, covering Python-based querying, cleaning, manipulation, and visualization with tools such as SQL, web scraping workflows, and modern data-collection practices.
+
+### FINTECH 502: FinTech Capstones
+- **Format:** Experiential learning capstone for FinTech MEng students.
+- **Highlights:** Guided student consulting teams as they delivered industry-sponsored projects that translate quantitative finance and machine learning research into deployable solutions for partner organizations.
+
+### FINTECH 520: Introduction to Statistics
+- **Format:** Core quantitative foundations course for incoming FinTech graduate students.
+- **Highlights:** Built the statistical toolkit—probability, inference, and modeling—required for advanced financial technology coursework and applied research.
+
+## University of Florence · School of Economics and Management
+
+### Python for Data Science (March–May & September–December 2020)
+- **Format:** Professional training program for students and practitioners.
+- **Highlights:** Introduced Python fundamentals alongside the scientific stack (NumPy, pandas, matplotlib, and related libraries) to support data analysis and the extraction of actionable insights.


### PR DESCRIPTION
## Summary
- replace the placeholder teaching page with descriptions of Duke FinTech graduate courses taught by Alessio Brini
- add the University of Florence Python for Data Science offering with its 2020 teaching terms

## Testing
- not run (markdown-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d8964e81b083318a89df8bd5af8391