### PR TITLE
Organize publications by status

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -2,7 +2,8 @@
   title={Crypto dynamics during market downturns: Another dotcom boom-bust cycle?},
   author={Brini, Alessio and Lenz, Jimmie and Rasiel, Emma},
   journal={Digital Asses Research \& Engineering Collaborative, Duke University},
-  year={2022}
+  year={2022},
+  keywords = {published}
 }
 
 @article{brini2023reinforcement,
@@ -12,7 +13,8 @@
   volume={67},
   pages={101139},
   year={2023},
-  publisher={Elsevier}
+  publisher={Elsevier},
+  keywords = {published}
 }
 
 
@@ -21,7 +23,8 @@
   title={A machine learning approach to forecasting honey production with tree-based methods},
   author={Brini, Alessio and Giovannini, Elisa and Smaniotto, Elia},
   journal={arXiv preprint arXiv:2304.01215},
-  year={2023}
+  year={2023},
+  keywords = {working-paper}
 }
 
 @article{brini2022assessing,
@@ -31,7 +34,8 @@
   volume={220},
   pages={110885},
   year={2022},
-  publisher={Elsevier}
+  publisher={Elsevier},
+  keywords = {published}
 }
 
 @article{brini2022bitcoin,
@@ -39,26 +43,30 @@
   author={Brini, Alessio and Lenz, Jimmie},
   journal={Available at SSRN},
   volume={4157711},
-  year={2022}
+  year={2022},
+  keywords = {working-paper}
 }
 
 @article{brini2022reinforcement,
   title={Reinforcement learning for sequential decision-making: a data driven approach for finance},
   author={Brini, Alessio and others},
   year={2022},
-  publisher={Scuola Normale Superiore}
+  publisher={Scuola Normale Superiore},
+  keywords = {published}
 }
 
 @article{brinitrading,
   title={Trading mean-reversion with reinforcement learning},
-  author={Brini, Alessio and Tantari, Daniele}
+  author={Brini, Alessio and Tantari, Daniele},
+  keywords = {published}
 }
 
 @article{brini2023honey,
   title={Honey-at-Risk: Honey Production Modeling via Factor Copulae with an application to Optimal Trigger Calibration for Weather-Indexed Insurance Contracts},
   author={Brini, Alessio and Lombardi, Ginevra Virginia and Mancino, Maria Elvira and Smaniotto, Elia and Toscano, Giacomo},
   journal={Available at SSRN 4562432},
-  year={2023}
+  year={2023},
+  keywords = {working-paper}
 }
 
 @article{brini2025spotv2net,
@@ -70,7 +78,8 @@
   pages={1093--1111},
   year={2025},
   publisher={Elsevier},
-  selected  = {true}
+  selected  = {true},
+  keywords = {published}
 }
 
 @article{brini2024comparison,
@@ -82,7 +91,8 @@
   pages={122},
   year={2024},
   publisher={Springer Berlin Heidelberg Berlin/Heidelberg},
-  selected  = {true}
+  selected  = {true},
+  keywords = {published}
 }
 
 @article{brini2024pricing,
@@ -93,7 +103,8 @@
   pages={106752},
   year={2024},
   publisher={North-Holland},
-  selected  = {true}
+  selected  = {true},
+  keywords = {published}
 }
 
 @article{brini2023deep,
@@ -104,7 +115,8 @@
   pages={128901},
   year={2023},
   publisher={Elsevier},
-  selected  = {true}
+  selected  = {true},
+  keywords = {published}
 }
 
 @inproceedings{brini2024data,
@@ -112,14 +124,16 @@
   author={Brini, Alessio and Domeniconi, Giacomo and Fathi, Ali},
   booktitle={Proceedings of the 5th ACM International Conference on AI in Finance},
   pages={478--486},
-  year={2024}
+  year={2024},
+  keywords = {published}
 }
 
 @article{xu2025improving,
   title={Improving DeFi Accessibility through Efficient Liquidity Provisioning with Deep Reinforcement Learning},
   author={Xu, Haonan and Brini, Alessio},
   journal={arXiv preprint arXiv:2501.07508},
-  year={2025}
+  year={2025},
+  keywords = {working-paper}
 }
 
 @article{brini2025modeling,
@@ -128,12 +142,14 @@
   journal={Soft Computing},
   pages={1--13},
   year={2025},
-  publisher={Springer Berlin Heidelberg Berlin/Heidelberg}
+  publisher={Springer Berlin Heidelberg Berlin/Heidelberg},
+  keywords = {published}
 }
 
 @article{brini2025empirical,
   title={Empirical Models of the Time Evolution of SPX Option Prices},
   author={Brini, Alessio and Hsieh, David A and Kuiper, Patrick and Moushegian, Sean and Ye, David},
   journal={arXiv preprint arXiv:2506.17511},
-  year={2025}
+  year={2025},
+  keywords = {working-paper}
 }

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -8,6 +8,10 @@ nav_order: 1
 <!-- _pages/publications.md -->
 <div class="publications">
 
-  {% bibliography -f papers %}
+  <h2>Published Papers</h2>
+  {% bibliography -f papers -q @*[keywords=published]* --sort_by year --order descending %}
+
+  <h2>Working Papers</h2>
+  {% bibliography -f papers -q @*[keywords=working-paper]* --sort_by year --order descending %}
 
 </div>


### PR DESCRIPTION
## Summary
- add bibliography keywords to distinguish published work from arXiv/SSRN working papers
- split the publications page into published and working paper lists sorted by year in descending order

## Testing
- not run (jekyll executable not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d8a62dac2883318c0dedd7a5fb6cf5