### PR TITLE
Fix publication ordering with two-layered approach

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -1,49 +1,16 @@
-@article{brini2022crypto,
-  title={Crypto dynamics during market downturns: Another dotcom boom-bust cycle?},
-  author={Brini, Alessio and Lenz, Jimmie and Rasiel, Emma},
-  journal={Digital Asset Research \& Engineering Collaborative, Duke University},
-  year={2022},
+@article{brini2026nonlinear,
+  title={A Nonlinear Target-Factor Model with Attention Mechanism for Mixed-Frequency Data},
+  author={Brini, Alessio and Seregina, Ekaterina},
+  journal={arXiv preprint arXiv:2601.16274},
+  year={2026},
   keywords = {working-paper}
 }
 
-@article{brini2023reinforcement,
-  title={Reinforcement learning policy recommendation for interbank network stability},
-  author={Brini, Alessio and Tedeschi, Gabriele and Tantari, Daniele},
-  journal={Journal of Financial Stability},
-  volume={67},
-  pages={101139},
-  year={2023},
-  publisher={Elsevier},
-  keywords = {published}
-}
-
-
-
-@article{brini2023machine,
-  title={A machine learning approach to forecasting honey production with tree-based methods},
-  author={Brini, Alessio and Giovannini, Elisa and Smaniotto, Elia},
-  journal={arXiv preprint arXiv:2304.01215},
-  year={2023},
-  keywords = {working-paper}
-}
-
-@article{brini2022assessing,
-  title={Assessing the resiliency of investors against cryptocurrency market crashes through the leverage effect},
-  author={Brini, Alessio and Lenz, Jimmie},
-  journal={Economics Letters},
-  volume={220},
-  pages={110885},
-  year={2022},
-  publisher={Elsevier},
-  keywords = {published}
-}
-
-@article{brini2022bitcoin,
-  title={Bitcoin ETFs: Measuring the performance of this new market niche},
-  author={Brini, Alessio and Lenz, Jimmie},
-  journal={Available at SSRN},
-  volume={4157711},
-  year={2022},
+@article{juvinski2026stableaml,
+  title={StableAML: Machine Learning for Behavioral Wallet Detection in Stablecoin Anti-Money Laundering on Ethereum},
+  author={Juvinski, Luciano and Li, Haochen and Brini, Alessio},
+  journal={arXiv preprint arXiv:2602.17842},
+  year={2026},
   keywords = {working-paper}
 }
 
@@ -54,14 +21,6 @@
   pages={247--255},
   year={2025},
   keywords = {published}
-}
-
-@article{brini2023honey,
-  title={Honey-at-Risk: Honey Production Modeling via Factor Copulae with an application to Optimal Trigger Calibration for Weather-Indexed Insurance Contracts},
-  author={Brini, Alessio and Lombardi, Ginevra Virginia and Mancino, Maria Elvira and Smaniotto, Elia and Toscano, Giacomo},
-  journal={Available at SSRN 4562432},
-  year={2023},
-  keywords = {working-paper}
 }
 
 @article{brini2025spotv2net,
@@ -75,6 +34,32 @@
   publisher={Elsevier},
   selected  = {true},
   keywords = {published}
+}
+
+@article{brini2025modeling,
+  title={Modeling and simulating a startup ecosystem development with a delayed differential equation},
+  author={Brini, Alessio and Fanelli, Viviana},
+  journal={Soft Computing},
+  pages={1--13},
+  year={2025},
+  publisher={Springer Berlin Heidelberg Berlin/Heidelberg},
+  keywords = {published}
+}
+
+@article{xu2025improving,
+  title={Improving DeFi Accessibility through Efficient Liquidity Provisioning with Deep Reinforcement Learning},
+  author={Xu, Haonan and Brini, Alessio},
+  journal={arXiv preprint arXiv:2501.07508},
+  year={2025},
+  keywords = {working-paper}
+}
+
+@article{brini2025empirical,
+  title={Empirical Models of the Time Evolution of SPX Option Prices},
+  author={Brini, Alessio and Hsieh, David A and Kuiper, Patrick and Moushegian, Sean and Ye, David},
+  journal={arXiv preprint arXiv:2506.17511},
+  year={2025},
+  keywords = {working-paper}
 }
 
 @article{brini2024comparison,
@@ -102,6 +87,26 @@
   keywords = {published}
 }
 
+@inproceedings{brini2024data,
+  title={Data-driven Derivative Hedging with Quadratic Variation Penalty},
+  author={Brini, Alessio and Domeniconi, Giacomo and Fathi, Ali},
+  booktitle={Proceedings of the 5th ACM International Conference on AI in Finance},
+  pages={478--486},
+  year={2024},
+  keywords = {published}
+}
+
+@article{brini2023reinforcement,
+  title={Reinforcement learning policy recommendation for interbank network stability},
+  author={Brini, Alessio and Tedeschi, Gabriele and Tantari, Daniele},
+  journal={Journal of Financial Stability},
+  volume={67},
+  pages={101139},
+  year={2023},
+  publisher={Elsevier},
+  keywords = {published}
+}
+
 @article{brini2023deep,
   title={Deep reinforcement trading with predictable returns},
   author={Brini, Alessio and Tantari, Daniele},
@@ -114,53 +119,46 @@
   keywords = {published}
 }
 
-@inproceedings{brini2024data,
-  title={Data-driven Derivative Hedging with Quadratic Variation Penalty},
-  author={Brini, Alessio and Domeniconi, Giacomo and Fathi, Ali},
-  booktitle={Proceedings of the 5th ACM International Conference on AI in Finance},
-  pages={478--486},
-  year={2024},
+@article{brini2023machine,
+  title={A machine learning approach to forecasting honey production with tree-based methods},
+  author={Brini, Alessio and Giovannini, Elisa and Smaniotto, Elia},
+  journal={arXiv preprint arXiv:2304.01215},
+  year={2023},
+  keywords = {working-paper}
+}
+
+@article{brini2023honey,
+  title={Honey-at-Risk: Honey Production Modeling via Factor Copulae with an application to Optimal Trigger Calibration for Weather-Indexed Insurance Contracts},
+  author={Brini, Alessio and Lombardi, Ginevra Virginia and Mancino, Maria Elvira and Smaniotto, Elia and Toscano, Giacomo},
+  journal={Available at SSRN 4562432},
+  year={2023},
+  keywords = {working-paper}
+}
+
+@article{brini2022assessing,
+  title={Assessing the resiliency of investors against cryptocurrency market crashes through the leverage effect},
+  author={Brini, Alessio and Lenz, Jimmie},
+  journal={Economics Letters},
+  volume={220},
+  pages={110885},
+  year={2022},
+  publisher={Elsevier},
   keywords = {published}
 }
 
-@article{xu2025improving,
-  title={Improving DeFi Accessibility through Efficient Liquidity Provisioning with Deep Reinforcement Learning},
-  author={Xu, Haonan and Brini, Alessio},
-  journal={arXiv preprint arXiv:2501.07508},
-  year={2025},
+@article{brini2022crypto,
+  title={Crypto dynamics during market downturns: Another dotcom boom-bust cycle?},
+  author={Brini, Alessio and Lenz, Jimmie and Rasiel, Emma},
+  journal={Digital Asset Research \& Engineering Collaborative, Duke University},
+  year={2022},
   keywords = {working-paper}
 }
 
-@article{brini2025modeling,
-  title={Modeling and simulating a startup ecosystem development with a delayed differential equation},
-  author={Brini, Alessio and Fanelli, Viviana},
-  journal={Soft Computing},
-  pages={1--13},
-  year={2025},
-  publisher={Springer Berlin Heidelberg Berlin/Heidelberg},
-  keywords = {published}
-}
-
-@article{brini2025empirical,
-  title={Empirical Models of the Time Evolution of SPX Option Prices},
-  author={Brini, Alessio and Hsieh, David A and Kuiper, Patrick and Moushegian, Sean and Ye, David},
-  journal={arXiv preprint arXiv:2506.17511},
-  year={2025},
-  keywords = {working-paper}
-}
-
-@article{brini2026nonlinear,
-  title={A Nonlinear Target-Factor Model with Attention Mechanism for Mixed-Frequency Data},
-  author={Brini, Alessio and Seregina, Ekaterina},
-  journal={arXiv preprint arXiv:2601.16274},
-  year={2026},
-  keywords = {working-paper}
-}
-
-@article{juvinski2026stableaml,
-  title={StableAML: Machine Learning for Behavioral Wallet Detection in Stablecoin Anti-Money Laundering on Ethereum},
-  author={Juvinski, Luciano and Li, Haochen and Brini, Alessio},
-  journal={arXiv preprint arXiv:2602.17842},
-  year={2026},
+@article{brini2022bitcoin,
+  title={Bitcoin ETFs: Measuring the performance of this new market niche},
+  author={Brini, Alessio and Lenz, Jimmie},
+  journal={Available at SSRN},
+  volume={4157711},
+  year={2022},
   keywords = {working-paper}
 }

--- a/_config.yml
+++ b/_config.yml
@@ -237,6 +237,9 @@ scholar:
   style: apa
   locale: en
 
+  sort_by: year
+  order: descending
+
   source: /_bibliography/
   bibliography: papers.bib
   bibliography_template: bib


### PR DESCRIPTION
1. Add global sort_by/order to scholar config in _config.yml so Jekyll Scholar sorts by year descending at the configuration level, which is more reliable than inline tag options.

2. Reorder papers.bib entries by year descending as a guaranteed fallback — when Jekyll Scholar reads the file sequentially and filters by keyword, each filtered subset (published / working-paper) will already be in the correct chronological order regardless of whether the sort mechanism is applied.

https://claude.ai/code/session_01Arm1KLGa1M5ooGbjXxQesE